### PR TITLE
Fix: Replace missing method in verifying email

### DIFF
--- a/emails/views.py
+++ b/emails/views.py
@@ -16,7 +16,7 @@ class ConfirmCodeView(APIView):
         code = request.data["code"]
 
         letter = VerifyEmailLetter.objects.get(user=user)
-        if letter.verify_email(code):
+        if code == letter.code:
             return Response("Email is verified", status.HTTP_200_OK)
 
         return Response("Wrong code", status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Summary

Fixed `AttributeError` on verifying email

## Changes Made

- Replaced missing method with comparison
- Resolved #7 issue

## Checklist

- [ ] I have added docstrings to code in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my feature works