### PR TITLE
Fix: Change permissions' checks order

### DIFF
--- a/users/permissions.py
+++ b/users/permissions.py
@@ -10,4 +10,4 @@ class IsEmailVerified(BasePermission):
 
 class IsEmailVerifiedOrReadOnly(IsEmailVerified):
     def has_permission(self, request, view):
-        return super().has_permission(request, view) or request.method in SAFE_METHODS
+        return request.method in SAFE_METHODS or super().has_permission(request, view)


### PR DESCRIPTION
## Summary

Fixed `AttributeError` on safe methods without authentication

## Changes Made

- Changed order of permissions to let read methods from anonymous users
- Resolved #13 issue

## Checklist

- [ ] I have added docstrings to code in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my feature works