### PR TITLE
Fix: Make autopopulated fields unavailable for updating

### DIFF
--- a/commons/mixins.py
+++ b/commons/mixins.py
@@ -1,5 +1,4 @@
 class BasePopulateDataMixin:
-    # TODO: Add docstrings
     def update_request(self, request):
         request.data._mutable = True
         request.data.update(self.get_populated_data())
@@ -11,16 +10,34 @@ class BasePopulateDataMixin:
 
 
 class PopulateCreateDataMixin(BasePopulateDataMixin):
+    """
+    Populate request's data on model create.
+
+    Override `.get_populated_data()` to provide updated data.
+    """
+
     def create(self, request, *args, **kwargs):
         request = self.update_request(request)
         return super().create(request, *args, **kwargs)
 
 
 class PopulateUpdateDataMixin(BasePopulateDataMixin):
+    """
+    Populate request's data on model update.
+
+    Override `.get_populated_data()` to provide updated data.
+    """
+
     def update(self, request, *args, **kwargs):
         request = self.update_request(request)
         return super().update(request, *args, **kwargs)
 
 
 class PopulateDataMixin(PopulateCreateDataMixin, PopulateUpdateDataMixin):
+    """
+    Populate request's data on model create and update.
+
+    Override `.get_populated_data()` to provide updated data.
+    """
+
     pass

--- a/commons/mixins.py
+++ b/commons/mixins.py
@@ -1,0 +1,26 @@
+class BasePopulateDataMixin:
+    # TODO: Add docstrings
+    def update_request(self, request):
+        request.data._mutable = True
+        request.data.update(self.get_populated_data())
+        request.data._mutable = False
+        return request
+
+    def get_populated_data(self):
+        raise NotImplementedError()
+
+
+class PopulateCreateDataMixin(BasePopulateDataMixin):
+    def create(self, request, *args, **kwargs):
+        request = self.update_request(request)
+        return super().create(request, *args, **kwargs)
+
+
+class PopulateUpdateDataMixin(BasePopulateDataMixin):
+    def update(self, request, *args, **kwargs):
+        request = self.update_request(request)
+        return super().update(request, *args, **kwargs)
+
+
+class PopulateDataMixin(PopulateCreateDataMixin, PopulateUpdateDataMixin):
+    pass

--- a/places/viewsets.py
+++ b/places/viewsets.py
@@ -1,13 +1,14 @@
 from rest_framework.viewsets import ModelViewSet
 
+from commons.mixins import PopulateDataMixin
+
 from .serializers import PlaceSerializer
 from .models import Place
 
 
-class PlaceViewSet(ModelViewSet):
+class PlaceViewSet(PopulateDataMixin, ModelViewSet):
     serializer_class = PlaceSerializer
     queryset = Place.objects.all()
 
-    def create(self, request, *args, **kwargs):
-        request.data["profile"] = self.request.user.profile.pk
-        return super().create(request, *args, **kwargs)
+    def get_populated_data(self):
+        return {"profile": self.request.user.profile.pk}

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -7,6 +7,3 @@ class ProfileSerializer(serializers.ModelSerializer):
     class Meta:
         model = Profile
         fields = "__all__"
-        extra_kwargs = {
-            "user": {"write_only": True},
-        }

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -2,24 +2,25 @@ from rest_framework import generics
 from rest_framework import permissions
 from rest_framework.parsers import MultiPartParser, FormParser
 
+from commons.mixins import PopulateCreateDataMixin, PopulateUpdateDataMixin
+
 from .serializers import ProfileSerializer
 from .models import Profile
 from .permissions import HasProfile
 
 
-class ProfileListView(generics.ListCreateAPIView):
+class ProfileListView(PopulateCreateDataMixin, generics.ListCreateAPIView):
     parser_classes = [MultiPartParser, FormParser]
     serializer_class = ProfileSerializer
     queryset = Profile.objects.all()
-
-    def create(self, request, *args, **kwargs):
-        request.data["user"] = self.request.user.pk
-        return super().create(request, *args, **kwargs)
 
     def get_permissions(self):
         if self.request.method == "POST":
             return [permissions.AllowAny()]
         return super().get_permissions()
+
+    def get_populated_data(self):
+        return {"user": self.request.user.pk}
 
 
 class ProfileDetailsView(generics.RetrieveAPIView):
@@ -27,7 +28,7 @@ class ProfileDetailsView(generics.RetrieveAPIView):
     queryset = Profile.objects.all()
 
 
-class MyProfileDetailsView(generics.RetrieveUpdateAPIView):
+class MyProfileDetailsView(PopulateUpdateDataMixin, generics.RetrieveUpdateAPIView):
     parser_classes = [MultiPartParser, FormParser]
     serializer_class = ProfileSerializer
     queryset = Profile.objects.all()
@@ -35,3 +36,6 @@ class MyProfileDetailsView(generics.RetrieveUpdateAPIView):
 
     def get_object(self):
         return self.request.user.profile
+
+    def get_populated_data(self):
+        return {"user": self.request.user.pk}


### PR DESCRIPTION
## Summary

Made autopopulated fields populated on update methods too

## Changes Made

- Created request's data populating mixins
- Applied these mixins to Place and Profile endpoints
- Resolved #16 issue

## Checklist

- [X] I have added docstrings to code in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my feature works