### PR TITLE
Fix: Add attribute existence check in PopulateDataMixin

### DIFF
--- a/commons/mixins.py
+++ b/commons/mixins.py
@@ -1,4 +1,3 @@
-from django.http import QueryDict
 
 
 class BasePopulateDataMixin:

--- a/commons/mixins.py
+++ b/commons/mixins.py
@@ -1,8 +1,11 @@
+from django.http import QueryDict
+
+
 class BasePopulateDataMixin:
     def update_request(self, request):
-        request.data._mutable = True
+        if isinstance(request.data, QueryDict):
+            request.data._mutable = True
         request.data.update(self.get_populated_data())
-        request.data._mutable = False
         return request
 
     def get_populated_data(self):

--- a/commons/mixins.py
+++ b/commons/mixins.py
@@ -3,7 +3,7 @@ from django.http import QueryDict
 
 class BasePopulateDataMixin:
     def update_request(self, request):
-        if isinstance(request.data, QueryDict):
+        if hasattr(request.data, "_mutable") and request.data._mutable is False:
             request.data._mutable = True
         request.data.update(self.get_populated_data())
         return request


### PR DESCRIPTION
## Summary

Fix `AttributeError` on populating request's data dict with `PopulateDataMixin` in some endpoints

## Changes Made

- Added type check to avoid changing mutability on mutable dicts
- Resolved #22 issue

## Checklist

- [ ] I have added comments to code in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my feature works