### PR TITLE
Feature: Adapt request's data populate mixin to use url's arguments

### DIFF
--- a/commons/mixins.py
+++ b/commons/mixins.py
@@ -1,11 +1,11 @@
 class BasePopulateDataMixin:
-    def update_request(self, request):
+    def update_request(self, request, *args, **kwargs):
         if hasattr(request.data, "_mutable") and request.data._mutable is False:
             request.data._mutable = True
-        request.data.update(self.get_populated_data())
+        request.data.update(self.get_populated_data(*args, **kwargs))
         return request
 
-    def get_populated_data(self):
+    def get_populated_data(self, *args, **kwargs):
         raise NotImplementedError()
 
 
@@ -17,7 +17,7 @@ class PopulateCreateDataMixin(BasePopulateDataMixin):
     """
 
     def create(self, request, *args, **kwargs):
-        request = self.update_request(request)
+        request = self.update_request(request, *args, **kwargs)
         return super().create(request, *args, **kwargs)
 
 
@@ -29,7 +29,7 @@ class PopulateUpdateDataMixin(BasePopulateDataMixin):
     """
 
     def update(self, request, *args, **kwargs):
-        request = self.update_request(request)
+        request = self.update_request(request, *args, **kwargs)
         return super().update(request, *args, **kwargs)
 
 


### PR DESCRIPTION
## Summary

Provide url dispatcher's kwargs to `PopulateDataMixin`

## Changes Made

- Passed url's kwargs to `.get_populated_data()` to provide wider usage
- Used `PopulateDataMixin` in Media views

## Checklist

- [ ] I have added comments to code in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my feature works
