### PR TITLE
Feature: Change Media views incoming data

### DIFF
--- a/media/models.py
+++ b/media/models.py
@@ -1,21 +1,8 @@
 from django.contrib.gis.db import models
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
-from operator import or_
-from functools import reduce
 
 from .validators import MimeTypeValidator
-
-related_content_types = [
-    {
-        "app_label": "places",
-        "model": "place",
-    },
-    {
-        "app_label": "events",
-        "model": "event",
-    },
-]
 
 
 class Media(models.Model):
@@ -40,16 +27,8 @@ class Media(models.Model):
     content_type = models.ForeignKey(
         ContentType,
         on_delete=models.CASCADE,
-        limit_choices_to=reduce(
-            or_,
-            [
-                models.Q(
-                    app_label=content_type["app_label"],
-                    model=content_type["model"],
-                )
-                for content_type in related_content_types
-            ],
-        ),
+        limit_choices_to=models.Q(app_label="places", model="place")
+        | models.Q(app_label="events", model="event"),
     )
     object_id = models.PositiveIntegerField()
     content_object = GenericForeignKey()

--- a/media/serializers.py
+++ b/media/serializers.py
@@ -15,7 +15,7 @@ class MediaSerializer(serializers.ModelSerializer):
 
 class MultipleMediaSerializer(serializers.Serializer):
     files = serializers.ListField(child=serializers.FileField())
-    content_type = serializers.CharField(write_only=True)
+    content_type = serializers.IntegerField(write_only=True)
     object_id = serializers.IntegerField(write_only=True)
 
     def create(self, validated_data):

--- a/media/serializers.py
+++ b/media/serializers.py
@@ -38,3 +38,9 @@ class MultipleMediaSerializer(serializers.Serializer):
         for obj in data["files"]:
             result["files"].append(MediaSerializer().to_representation(obj))
         return result
+
+
+class SwaggerMultipleMediaSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    files = serializers.ListField(child=serializers.FileField())
+    model = serializers.CharField(write_only=True)

--- a/media/tests/base.py
+++ b/media/tests/base.py
@@ -39,13 +39,7 @@ class MediaFileTestCase(APITestCase):
 
     def post_media(self, **data):
         return self.client.post(
-            reverse(
-                "media:list",
-                kwargs={
-                    "app_label": "places",
-                    "object_id": self.place.pk,
-                },
-            ),
+            reverse("media:list"),
             data,
         )
 
@@ -53,7 +47,7 @@ class MediaFileTestCase(APITestCase):
         return self.client.delete(
             reverse(
                 "media:details",
-                kwargs={"app_label": "places", "object_id": self.place.pk, "pk": pk},
+                kwargs={"pk": pk},
             )
         )
 
@@ -61,7 +55,7 @@ class MediaFileTestCase(APITestCase):
         return self.client.put(
             reverse(
                 "media:details",
-                kwargs={"app_label": "places", "object_id": self.place.pk, "pk": pk},
+                kwargs={"pk": pk},
             ),
             data,
             "multipart",
@@ -71,7 +65,7 @@ class MediaFileTestCase(APITestCase):
         return self.client.patch(
             reverse(
                 "media:details",
-                kwargs={"app_label": "places", "object_id": self.place.pk, "pk": pk},
+                kwargs={"pk": pk},
             ),
             data,
             "multipart",

--- a/media/tests/test_handlers.py
+++ b/media/tests/test_handlers.py
@@ -34,5 +34,11 @@ class FileRemovalTestCase(MediaFileTestCase):
         file = SimpleUploadedFile(
             "video.mp4", self.dir.contents["video.mp4"], "video/mp4"
         )
-        self.put_media(self.media.pk, file=file, order=self.media.order)
+        self.put_media(
+            self.media.pk,
+            file=file,
+            order=self.media.order,
+            object_id=self.media.object_id,
+            model="place",
+        )
         self.assert_old_file_removal()

--- a/media/tests/test_validators.py
+++ b/media/tests/test_validators.py
@@ -26,7 +26,7 @@ class MimeTypeValidatorTestCase(MediaFileTestCase):
                 content_type="text/plain",
             ),
         ]
-        response = self.post_media(files=files)
+        response = self.post_media(files=files, model="place", object_id=self.place.pk)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_invalid_mime_type(self):
@@ -43,5 +43,5 @@ class MimeTypeValidatorTestCase(MediaFileTestCase):
             ),
             SimpleUploadedFile("text", self.dir.contents["text.txt"], content_type=""),
         ]
-        response = self.post_media(files=files)
+        response = self.post_media(files=files, model="place", object_id=self.place.pk)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/media/views.py
+++ b/media/views.py
@@ -1,13 +1,28 @@
 from rest_framework.generics import ListCreateAPIView, RetrieveUpdateDestroyAPIView
 from rest_framework.parsers import MultiPartParser, FormParser
+from rest_framework.status import HTTP_201_CREATED
 from django.contrib.contenttypes.models import ContentType
+from django.utils.decorators import method_decorator
+
+from drf_yasg.utils import swagger_auto_schema
 
 from commons.mixins import PopulateCreateDataMixin, PopulateUpdateDataMixin
 
-from .serializers import MediaSerializer, MultipleMediaSerializer
+from .serializers import (
+    MediaSerializer,
+    MultipleMediaSerializer,
+    SwaggerMultipleMediaSerializer,
+)
 from .models import Media
 
 
+@method_decorator(
+    name="post",
+    decorator=swagger_auto_schema(
+        request_body=SwaggerMultipleMediaSerializer(),
+        responses={HTTP_201_CREATED: SwaggerMultipleMediaSerializer()},
+    ),
+)
 class MediaListView(PopulateCreateDataMixin, ListCreateAPIView):
     parser_classes = [MultiPartParser, FormParser]
     queryset = Media.objects.all()

--- a/media/views.py
+++ b/media/views.py
@@ -1,11 +1,14 @@
 from rest_framework.generics import ListCreateAPIView, RetrieveUpdateDestroyAPIView
 from rest_framework.parsers import MultiPartParser, FormParser
+from django.contrib.contenttypes.models import ContentType
+
+from commons.mixins import PopulateCreateDataMixin, PopulateUpdateDataMixin
 
 from .serializers import MediaSerializer, MultipleMediaSerializer
 from .models import Media
 
 
-class MediaListView(ListCreateAPIView):
+class MediaListView(PopulateCreateDataMixin, ListCreateAPIView):
     parser_classes = [MultiPartParser, FormParser]
     queryset = Media.objects.all()
 
@@ -14,8 +17,19 @@ class MediaListView(ListCreateAPIView):
             return MultipleMediaSerializer
         return MediaSerializer
 
+    def get_populated_data(self, *args, **kwargs):
+        content_type = ContentType.objects.get(model=self.request.data["model"])
+        return {"content_type": content_type.pk}
 
-class MediaDetailsView(RetrieveUpdateDestroyAPIView):
+
+class MediaDetailsView(PopulateUpdateDataMixin, RetrieveUpdateDestroyAPIView):
     parser_classes = [MultiPartParser, FormParser]
     serializer_class = MediaSerializer
     queryset = Media.objects.all()
+
+    def get_populated_data(self, *args, **kwargs):
+        model = self.request.data.get("model", None)
+        if model:
+            content_type = ContentType.objects.get(model=model)
+            return {"content_type": content_type.pk}
+        return {}

--- a/media/views.py
+++ b/media/views.py
@@ -1,39 +1,11 @@
 from rest_framework.generics import ListCreateAPIView, RetrieveUpdateDestroyAPIView
 from rest_framework.parsers import MultiPartParser, FormParser
-from django.contrib.contenttypes.models import ContentType
-
-from commons.mixins import PopulateDataMixin
 
 from .serializers import MediaSerializer, MultipleMediaSerializer
-from .models import Media, related_content_types
+from .models import Media
 
 
-class ContentObjectViewMixin(PopulateDataMixin):
-    def filter_queryset_by_content_object(self, app_label, object_id):
-        filters = self.get_content_type_filters(app_label)
-        return self.queryset.filter(object_id=object_id, **filters).all()
-
-    def get_content_type_filters(self, app_label):
-        return next(
-            kwargs
-            for kwargs in related_content_types
-            if kwargs["app_label"] == app_label
-        )
-
-    def get_content_object_data(self, app_label, object_id):
-        filters = self.get_content_type_filters(app_label)
-        return {
-            "content_type": ContentType.objects.get(**filters).pk,
-            "object_id": object_id,
-        }
-
-    def get_populated_data(self, *args, **kwargs):
-        app_label = kwargs["app_label"]
-        object_id = kwargs["object_id"]
-        return self.get_content_object_data(app_label, object_id)
-
-
-class MediaListView(ContentObjectViewMixin, ListCreateAPIView):
+class MediaListView(ListCreateAPIView):
     parser_classes = [MultiPartParser, FormParser]
     queryset = Media.objects.all()
 
@@ -42,13 +14,8 @@ class MediaListView(ContentObjectViewMixin, ListCreateAPIView):
             return MultipleMediaSerializer
         return MediaSerializer
 
-    # TODO: To test on different endpoints in one run
-    def list(self, request, app_label, object_id):
-        self.queryset = self.filter_queryset_by_content_object(app_label, object_id)
-        return super().list(request)
 
-
-class MediaDetailsView(ContentObjectViewMixin, RetrieveUpdateDestroyAPIView):
+class MediaDetailsView(RetrieveUpdateDestroyAPIView):
     parser_classes = [MultiPartParser, FormParser]
     serializer_class = MediaSerializer
     queryset = Media.objects.all()

--- a/near/urls.py
+++ b/near/urls.py
@@ -15,7 +15,7 @@ router.register("events", EventViewSet, basename="event")
 urlpatterns = (
     [
         path("", include(router.urls)),
-        path("<str:app_label>/<int:object_id>/media/", include("media.urls")),
+        path("media/", include("media.urls")),
         path("tokens/", include("tokens.urls")),
         path("users/", include("users.urls")),
         path("profiles/", include("profiles.urls")),


### PR DESCRIPTION
## Summary

Alter Media endpoints to resolve generic foreign key via POST data

## Changes Made

- Changed Media views to resolve generic foreign key by provided `object_id` and `model` via POST data
- Added OpenAPI requests & responses descriptions to Media views
- Adjusted tests according to the new implementation

## Checklist

- [ ] I have added comments to code in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my feature works
