### PR TITLE
Refactor Media views

### DIFF
--- a/events/urls.py
+++ b/events/urls.py
@@ -1,0 +1,14 @@
+from django.urls import path
+
+from media.views import media_create_view_factory
+
+from .models import Event
+
+
+app_name = "events"
+
+EventMediaView = media_create_view_factory(Event)
+
+urlpatterns = [
+    path("<int:pk>/media/", EventMediaView.as_view(), name="media"),
+]

--- a/media/models.py
+++ b/media/models.py
@@ -1,21 +1,8 @@
 from django.contrib.gis.db import models
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
-from operator import or_
-from functools import reduce
 
 from .validators import MimeTypeValidator
-
-related_content_types = [
-    {
-        "app_label": "places",
-        "model": "place",
-    },
-    {
-        "app_label": "events",
-        "model": "event",
-    },
-]
 
 
 class Media(models.Model):
@@ -40,16 +27,8 @@ class Media(models.Model):
     content_type = models.ForeignKey(
         ContentType,
         on_delete=models.CASCADE,
-        limit_choices_to=reduce(
-            or_,
-            [
-                models.Q(
-                    app_label=content_type["app_label"],
-                    model=content_type["model"],
-                )
-                for content_type in related_content_types
-            ],
-        ),
+        limit_choices_to=models.Q(app_label="places", model="place")
+        | models.Q(app_label="events", model="event"),
     )
     object_id = models.PositiveIntegerField()
     content_object = GenericForeignKey()

--- a/media/tests/base.py
+++ b/media/tests/base.py
@@ -48,10 +48,28 @@ class MediaFileTestCase(APITestCase):
             data,
         )
 
+    def put_media(self, pk, **data):
+        return self.client.put(
+            reverse(
+                "media:details",
+                kwargs={"pk": pk},
+            ),
+            data,
+        )
+
+    def patch_media(self, pk, **data):
+        return self.client.patch(
+            reverse(
+                "media:details",
+                kwargs={"pk": pk},
+            ),
+            data,
+        )
+
     def delete_place_media(self, pk):
         return self.client.delete(
             reverse(
-                "media:delete",
+                "media:details",
                 kwargs={"pk": pk},
             )
         )

--- a/media/tests/base.py
+++ b/media/tests/base.py
@@ -37,42 +37,21 @@ class MediaFileTestCase(APITestCase):
     def tearDownClass(cls):
         cls.dir.close_all()
 
-    def post_media(self, **data):
+    def post_place_media(self, **data):
         return self.client.post(
             reverse(
-                "media:list",
+                "places:media",
                 kwargs={
-                    "app_label": "places",
-                    "object_id": self.place.pk,
+                    "pk": self.place.pk,
                 },
             ),
             data,
         )
 
-    def delete_media(self, pk):
+    def delete_place_media(self, pk):
         return self.client.delete(
             reverse(
-                "media:details",
-                kwargs={"app_label": "places", "object_id": self.place.pk, "pk": pk},
+                "media:delete",
+                kwargs={"pk": pk},
             )
-        )
-
-    def put_media(self, pk, **data):
-        return self.client.put(
-            reverse(
-                "media:details",
-                kwargs={"app_label": "places", "object_id": self.place.pk, "pk": pk},
-            ),
-            data,
-            "multipart",
-        )
-
-    def patch_media(self, pk, **data):
-        return self.client.patch(
-            reverse(
-                "media:details",
-                kwargs={"app_label": "places", "object_id": self.place.pk, "pk": pk},
-            ),
-            data,
-            "multipart",
         )

--- a/media/tests/test_handlers.py
+++ b/media/tests/test_handlers.py
@@ -20,19 +20,5 @@ class FileRemovalTestCase(MediaFileTestCase):
         self.assertFalse(self.storage.exists(self.old_file.name))
 
     def test_file_removal_on_delete(self):
-        self.delete_media(self.media.pk)
-        self.assert_old_file_removal()
-
-    def test_file_removal_on_patch(self):
-        file = SimpleUploadedFile(
-            "video.mp4", self.dir.contents["video.mp4"], "video/mp4"
-        )
-        self.patch_media(self.media.pk, file=file, order=self.media.order)
-        self.assert_old_file_removal()
-
-    def test_file_removal_on_put(self):
-        file = SimpleUploadedFile(
-            "video.mp4", self.dir.contents["video.mp4"], "video/mp4"
-        )
-        self.put_media(self.media.pk, file=file, order=self.media.order)
+        self.delete_place_media(self.media.pk)
         self.assert_old_file_removal()

--- a/media/tests/test_handlers.py
+++ b/media/tests/test_handlers.py
@@ -19,6 +19,20 @@ class FileRemovalTestCase(MediaFileTestCase):
     def assert_old_file_removal(self):
         self.assertFalse(self.storage.exists(self.old_file.name))
 
+    def test_file_removal_on_patch(self):
+        file = SimpleUploadedFile(
+            "video.mp4", self.dir.contents["video.mp4"], "video/mp4"
+        )
+        self.patch_media(self.media.pk, file=file)
+        self.assert_old_file_removal()
+
+    def test_file_removal_on_put(self):
+        file = SimpleUploadedFile(
+            "video.mp4", self.dir.contents["video.mp4"], "video/mp4"
+        )
+        self.put_media(self.media.pk, file=file, order=self.media.order)
+        self.assert_old_file_removal()
+
     def test_file_removal_on_delete(self):
         self.delete_place_media(self.media.pk)
         self.assert_old_file_removal()

--- a/media/tests/test_validators.py
+++ b/media/tests/test_validators.py
@@ -26,7 +26,7 @@ class MimeTypeValidatorTestCase(MediaFileTestCase):
                 content_type="text/plain",
             ),
         ]
-        response = self.post_media(files=files)
+        response = self.post_place_media(files=files)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_invalid_mime_type(self):
@@ -43,5 +43,5 @@ class MimeTypeValidatorTestCase(MediaFileTestCase):
             ),
             SimpleUploadedFile("text", self.dir.contents["text.txt"], content_type=""),
         ]
-        response = self.post_media(files=files)
+        response = self.post_place_media(files=files)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/media/urls.py
+++ b/media/urls.py
@@ -1,10 +1,10 @@
 from django.urls import path
 
-from .views import MediaDeleteView
+from .views import MediaDetailsView
 
 
 app_name = "media"
 
 urlpatterns = [
-    path("<int:pk>/", MediaDeleteView.as_view(), name="delete"),
+    path("<int:pk>/", MediaDetailsView.as_view(), name="details"),
 ]

--- a/media/urls.py
+++ b/media/urls.py
@@ -1,19 +1,5 @@
-from django.urls import path
-
-from .views import MediaListView, MediaDetailsView
-
-
-app_name = "media"
+app_name = 'media'
 
 urlpatterns = [
-    path(
-        "",
-        MediaListView.as_view(),
-        name="list",
-    ),
-    path(
-        "<int:pk>/",
-        MediaDetailsView.as_view(),
-        name="details",
-    ),
+    
 ]

--- a/media/urls.py
+++ b/media/urls.py
@@ -1,5 +1,10 @@
-app_name = 'media'
+from django.urls import path
+
+from .views import MediaDeleteView
+
+
+app_name = "media"
 
 urlpatterns = [
-    
+    path("<int:pk>/", MediaDeleteView.as_view(), name="delete"),
 ]

--- a/media/views.py
+++ b/media/views.py
@@ -1,54 +1,38 @@
-from rest_framework.generics import ListCreateAPIView, RetrieveUpdateDestroyAPIView
+from rest_framework.generics import CreateAPIView
 from rest_framework.parsers import MultiPartParser, FormParser
 from django.contrib.contenttypes.models import ContentType
+from copy import copy
 
 from commons.mixins import PopulateDataMixin
 
 from .serializers import MediaSerializer, MultipleMediaSerializer
-from .models import Media, related_content_types
+from .models import Media
 
 
-class ContentObjectViewMixin(PopulateDataMixin):
-    def filter_queryset_by_content_object(self, app_label, object_id):
-        filters = self.get_content_type_filters(app_label)
-        return self.queryset.filter(object_id=object_id, **filters).all()
-
-    def get_content_type_filters(self, app_label):
-        return next(
-            kwargs
-            for kwargs in related_content_types
-            if kwargs["app_label"] == app_label
-        )
-
-    def get_content_object_data(self, app_label, object_id):
-        filters = self.get_content_type_filters(app_label)
-        return {
-            "content_type": ContentType.objects.get(**filters).pk,
-            "object_id": object_id,
-        }
-
-    def get_populated_data(self, *args, **kwargs):
-        app_label = kwargs["app_label"]
-        object_id = kwargs["object_id"]
-        return self.get_content_object_data(app_label, object_id)
+"""
+POST: events/13/media/ -> append multiple media with continuous `order` to this model
+DELETE: media/<pk>/ -> delete certain media shifting `order`
+PATCH: events/13/media/ -> change order of this model's media 
+"""
 
 
-class MediaListView(ContentObjectViewMixin, ListCreateAPIView):
+def media_create_view_factory(model):
+    class MediaCreateView(GenericMediaCreateView):
+        content_type_pk = ContentType.objects.get_for_model(model).pk
+
+    return MediaCreateView
+
+
+class GenericMediaCreateView(PopulateDataMixin, CreateAPIView):
     parser_classes = [MultiPartParser, FormParser]
     queryset = Media.objects.all()
+    content_type_pk = None
 
     def get_serializer_class(self):
         if self.request.method == "POST":
             return MultipleMediaSerializer
         return MediaSerializer
 
-    # TODO: To test on different endpoints in one run
-    def list(self, request, app_label, object_id):
-        self.queryset = self.filter_queryset_by_content_object(app_label, object_id)
-        return super().list(request)
-
-
-class MediaDetailsView(ContentObjectViewMixin, RetrieveUpdateDestroyAPIView):
-    parser_classes = [MultiPartParser, FormParser]
-    serializer_class = MediaSerializer
-    queryset = Media.objects.all()
+    def get_populated_data(self, pk):
+        print(ContentType.objects.get(pk=self.content_type_pk).model, pk)
+        return {"content_type": self.content_type_pk, "object_id": pk}

--- a/media/views.py
+++ b/media/views.py
@@ -1,4 +1,4 @@
-from rest_framework.generics import CreateAPIView
+from rest_framework.generics import CreateAPIView, DestroyAPIView
 from rest_framework.parsers import MultiPartParser, FormParser
 from django.contrib.contenttypes.models import ContentType
 from copy import copy
@@ -14,6 +14,10 @@ POST: events/13/media/ -> append multiple media with continuous `order` to this 
 DELETE: media/<pk>/ -> delete certain media shifting `order`
 PATCH: events/13/media/ -> change order of this model's media 
 """
+
+
+class MediaDeleteView(DestroyAPIView):
+    queryset = Media.objects.all()
 
 
 def media_create_view_factory(model):

--- a/near/urls.py
+++ b/near/urls.py
@@ -8,6 +8,7 @@ from events.viewsets import EventViewSet
 
 from .schema import schema_view
 
+
 router = DefaultRouter()
 router.register("places", PlaceViewSet, basename="place")
 router.register("events", EventViewSet, basename="event")
@@ -15,10 +16,12 @@ router.register("events", EventViewSet, basename="event")
 urlpatterns = (
     [
         path("", include(router.urls)),
-        path("<str:app_label>/<int:object_id>/media/", include("media.urls")),
+        path("media/", include("media.urls")),
         path("tokens/", include("tokens.urls")),
         path("users/", include("users.urls")),
         path("profiles/", include("profiles.urls")),
+        path("places/", include("places.urls")),
+        path("events/", include("events.urls")),
         path("emails/", include("emails.urls")),
         path(
             "schema/",

--- a/places/urls.py
+++ b/places/urls.py
@@ -1,0 +1,14 @@
+from django.urls import path
+
+from media.views import media_create_view_factory
+
+from .models import Place
+
+
+app_name = "places"
+
+PlaceMediaView = media_create_view_factory(Place)
+
+urlpatterns = [
+    path("<int:pk>/media/", PlaceMediaView.as_view(), name="media"),
+]


### PR DESCRIPTION
## Summary

Change Media resolving `content_type` to creating view for each related model

## Changes Made

- Created Media view factory
- Added shifting `order` field when deleting Media
- Added appending Media to the end of order
- Adjusted tests' path reversing

## Checklist

- [ ] I have added comments to code in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my feature works