### PR TITLE
Remove redundant url's kwargs

### DIFF
--- a/commons/mixins.py
+++ b/commons/mixins.py
@@ -1,11 +1,11 @@
 class BasePopulateDataMixin:
-    def update_request(self, request, *args, **kwargs):
+    def update_request(self, request):
         if hasattr(request.data, "_mutable") and request.data._mutable is False:
             request.data._mutable = True
-        request.data.update(self.get_populated_data(*args, **kwargs))
+        request.data.update(self.get_populated_data())
         return request
 
-    def get_populated_data(self, *args, **kwargs):
+    def get_populated_data(self):
         raise NotImplementedError()
 
 
@@ -17,7 +17,7 @@ class PopulateCreateDataMixin(BasePopulateDataMixin):
     """
 
     def create(self, request, *args, **kwargs):
-        request = self.update_request(request, *args, **kwargs)
+        request = self.update_request(request)
         return super().create(request, *args, **kwargs)
 
 
@@ -29,9 +29,7 @@ class PopulateUpdateDataMixin(BasePopulateDataMixin):
     """
 
     def update(self, request, *args, **kwargs):
-        url_kwargs = kwargs
-        url_kwargs.pop("partial")
-        request = self.update_request(request, *args, **url_kwargs)
+        request = self.update_request(request)
         return super().update(request, *args, **kwargs)
 
 

--- a/events/viewsets.py
+++ b/events/viewsets.py
@@ -10,5 +10,5 @@ class EventViewSet(PopulateDataMixin, ModelViewSet):
     serializer_class = EventSerializer
     queryset = Event.objects.all()
 
-    def get_populated_data(self, pk):
+    def get_populated_data(self):
         return {"profile": self.request.user.profile.pk}

--- a/media/views.py
+++ b/media/views.py
@@ -26,7 +26,7 @@ class MediaDetailsView(PopulateUpdateDataMixin, RetrieveUpdateDestroyAPIView):
             media.order -= 1
         queryset.bulk_update(next_media, ["order"])
 
-    def get_populated_data(self, *args, **kwargs):
+    def get_populated_data(self):
         instance = self.get_object()
 
         return {
@@ -52,5 +52,5 @@ class GenericMediaCreateView(PopulateCreateDataMixin, CreateAPIView):
             return MultipleMediaSerializer
         return MediaSerializer
 
-    def get_populated_data(self, pk):
-        return {"content_type": self.content_type_pk, "object_id": pk}
+    def get_populated_data(self):
+        return {"content_type": self.content_type_pk, "object_id": self.kwargs["pk"]}

--- a/places/viewsets.py
+++ b/places/viewsets.py
@@ -10,5 +10,5 @@ class PlaceViewSet(PopulateDataMixin, ModelViewSet):
     serializer_class = PlaceSerializer
     queryset = Place.objects.all()
 
-    def get_populated_data(self, pk):
+    def get_populated_data(self):
         return {"profile": self.request.user.profile.pk}


### PR DESCRIPTION
## Summary

Remove redundant url's kwargs from `PopulateDataMixin`

## Changes Made

- Removed url's kwargs passing to `.get_populated_data()`
- Changed `PopulateDataMixin` children's methods accordingly

## Checklist

- [ ] I have added comments to code in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my feature works